### PR TITLE
Fixed onChange event for React Native 0.47, onChange no longer suppor…

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,7 +114,7 @@ export class MentionsTextInput extends Component {
 
         <TextInput
           {...this.props}
-          onChange={(event) => {
+          onContentSizeChange={(event) => {
             this.setState({
               textInputHeight: this.props.textInputMinHeight >= event.nativeEvent.contentSize.height ? this.props.textInputMinHeight : event.nativeEvent.contentSize.height,
             });


### PR DESCRIPTION
…ts event.nativeEvent.contentSize.height however, it has been replaced with onContentSizeChange